### PR TITLE
Add GitHub token authentication via env var

### DIFF
--- a/src/ai_funcs.rs
+++ b/src/ai_funcs.rs
@@ -11,7 +11,7 @@ const COMPLETION_TOKENS: u16 = 1024;
 
 pub async fn code_review(output: String) -> Result<(), Box<dyn std::error::Error>> {
     let system_message: &str = "You are a code reviewer. You provide your response in markdown, \
-    using a heading (`## path/filename.ext`) for  each file reviewed; normal text for your comment; \
+    using a heading (`## path/filename.ext`) for each file reviewed; normal text for your comment; \
     and, potentially, code blocks for code snippets relating to suggested changes \
     (```language...\n```). Don't bother commenting on everything, just focus on things you think \
     would benefit from being reworked. Very occasionally, you might add positive comments about \
@@ -50,8 +50,9 @@ pub async fn code_review(output: String) -> Result<(), Box<dyn std::error::Error
             Ok(response) => {
                 response.choices.iter().for_each(|chat_choice| {
                     if let Some(ref content) = chat_choice.delta.content {
-                        if let Err(_) = write!(lock, "{}", content) {
-                            eprintln!("{}", "ERROR: could not write to stdout".red());
+                        if let Err(e) = write!(lock, "{}", content) {
+                            eprintln!("{} {}", "ERROR:".red(), e);
+                            let _ = lock.flush();
                             process::exit(1);
                         }
                     }

--- a/src/ai_funcs.rs
+++ b/src/ai_funcs.rs
@@ -2,6 +2,7 @@ use async_openai::types::{
     ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestSystemMessageArgs,
     ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs,
 };
+use colored::Colorize;
 use futures::StreamExt;
 use std::io::{stdout, Write};
 use std::process;
@@ -9,13 +10,20 @@ use std::process;
 const COMPLETION_TOKENS: u16 = 1024;
 
 pub async fn code_review(output: String) -> Result<(), Box<dyn std::error::Error>> {
+    let system_message: &str = "You are a code reviewer. You provide your response in markdown, \
+    using a heading (`## path/filename.ext`) for  each file reviewed; normal text for your comment; \
+    and, potentially, code blocks for code snippets relating to suggested changes \
+    (```language...\n```). Don't bother commenting on everything, just focus on things you think \
+    would benefit from being reworked. Very occasionally, you might add positive comments about \
+    things that are particularly well executed, but this is entirely optional.";
+
     let client = async_openai::Client::new();
     let request = CreateChatCompletionRequestArgs::default()
         .max_tokens(COMPLETION_TOKENS)
         .model("gpt-4-1106-preview")
         .messages([
             ChatCompletionRequestSystemMessageArgs::default()
-                .content("You are a code reviewer. You provide your response in markdown, using a heading (`## path/filename.ext`) for each file reviewed; normal text for your comment; and, potentially, code blocks for code snippets relating to suggested changes (```language...```). Don't bother commenting on everything, just focus on things you think would benefit from being reworked. Very occasionally, you might add positive comments about things that are particularly well executed, but this is entirely optional.")
+                .content(system_message)
                 .build()?
                 .into(),
             ChatCompletionRequestUserMessageArgs::default()
@@ -35,25 +43,21 @@ pub async fn code_review(output: String) -> Result<(), Box<dyn std::error::Error
 
     let mut stream = client.chat().create_stream(request).await?;
 
-    println!("== START OF COMMENTS ==\n");
+    println!("# CRbot says:\n");
     let mut lock = stdout().lock();
     while let Some(result) = stream.next().await {
         match result {
             Ok(response) => {
                 response.choices.iter().for_each(|chat_choice| {
                     if let Some(ref content) = chat_choice.delta.content {
-                        if let Err(e) = write!(lock, "{}", content) {
-                            eprintln!("ERROR WRITING TO STDOUT: {}", e);
-                            process::exit(1)
+                        if let Err(_) = write!(lock, "{}", content) {
+                            eprintln!("{}", "ERROR: could not write to stdout".red());
+                            process::exit(1);
                         }
                     }
                 });
             }
-            Err(err) => {
-                if let Err(e) = writeln!(lock, "error: {err}") {
-                    return Err(e.into());
-                }
-            }
+            Err(err) => return Err(err.into()),
         }
         stdout().flush()?;
     }

--- a/src/ai_funcs.rs
+++ b/src/ai_funcs.rs
@@ -10,12 +10,15 @@ use std::process;
 const COMPLETION_TOKENS: u16 = 1024;
 
 pub async fn code_review(output: String) -> Result<(), Box<dyn std::error::Error>> {
-    let system_message: &str = "You are a code reviewer. You provide your response in markdown, \
-    using a heading (`## path/filename.ext`) for each file reviewed; normal text for your comment; \
-    and, potentially, code blocks for code snippets relating to suggested changes \
-    (```language...\n```). Don't bother commenting on everything, just focus on things you think \
-    would benefit from being reworked. Very occasionally, you might add positive comments about \
-    things that are particularly well executed, but this is entirely optional.";
+    let system_message: &str = "You are a code reviewer. \
+    You provide your response in markdown, \
+    using a heading (`## path/filename.ext`) for each file reviewed; \
+    normal text for your comment; and, potentially, code blocks for \
+    code snippets relating to suggested changes (```language...\n```). \
+    Don't bother commenting on everything, just focus on things you think \
+    would benefit from being reworked. Very occasionally, you might add \
+    positive comments about things that are particularly well executed, \
+    but this is entirely optional.";
 
     let client = async_openai::Client::new();
     let request = CreateChatCompletionRequestArgs::default()

--- a/src/ai_funcs.rs
+++ b/src/ai_funcs.rs
@@ -8,15 +8,16 @@ use std::io::{stdout, Write};
 const COMPLETION_TOKENS: u16 = 1024;
 
 pub async fn code_review(output: String) -> Result<(), Box<dyn std::error::Error>> {
-    let system_message: &str = "You are a code reviewer. \
-    You provide your response in markdown, \
-    using a heading (`## path/filename.ext`) for each file reviewed; \
-    normal text for your comment; and, potentially, code blocks for \
-    code snippets relating to suggested changes (```language...\n```). \
-    Don't bother commenting on everything, just focus on things you think \
-    would benefit from being reworked. Very occasionally, you might add \
-    positive comments about things that are particularly well executed, \
-    but this is entirely optional.";
+    let system_message: &str = "\
+You are a code reviewer. \
+You provide your response in markdown, \
+using a heading (`## path/filename.ext`) for each file reviewed; \
+normal text for your comment; and, potentially, code blocks for \
+code snippets relating to suggested changes (```language...\n```). \
+Don't bother commenting on everything, just focus on things you think \
+would benefit from being reworked. Very occasionally, you might add \
+positive comments about things that are particularly well executed, \
+but this is entirely optional.";
 
     let client = async_openai::Client::new();
     let request = CreateChatCompletionRequestArgs::default()

--- a/src/git_funcs.rs
+++ b/src/git_funcs.rs
@@ -89,22 +89,16 @@ pub async fn get_pr_info(
     };
 
     let response = request.send().await?;
-    let mut error= String::new();
     if response.status() != StatusCode::OK {
-        error.push_str(&format!(
-            "{} {}",
-            "GitHub API request failed. HTTP Status:",
-            response.status()
-        ));
-        if response.status() == reqwest::StatusCode::NOT_FOUND
-            || response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            error.push_str(&format!(
-                "{}",
-                "\nIf this is a private repo, GH_PR_TOKEN environment variable must be set."
-            ));
-        }
-        return Err(error.into())
+        let error_message = if response.status() == StatusCode::NOT_FOUND || response.status() == StatusCode::UNAUTHORIZED {
+            format!("GitHub API request failed with status: {}. \nIf this is a private repo, the 'GH_PR_TOKEN' environment variable must be set.", response.status())
+        } else {
+            format!("GitHub API request failed with status: {}.", response.status())
+        };
+
+        return Err(error_message.into())
     }
+
 
     let files_info: Vec<File> = response.json().await?;
 

--- a/src/git_funcs.rs
+++ b/src/git_funcs.rs
@@ -92,9 +92,17 @@ pub async fn get_pr_info(
 
     if response.status() != StatusCode::OK {
         eprintln!(
-            "{}",
-            "Error: GitHub API request failed. If this is a private repo, GH_PR_TOKEN environment variable must be set.".red()
+            "{} {}",
+            "Error: GitHub API request failed. HTTP Status:".red(),
+            response.status().as_str().red()
         );
+        if response.status() == reqwest::StatusCode::NOT_FOUND
+            || response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            eprintln!(
+                "{}",
+                "If this is a private repo, GH_PR_TOKEN environment variable must be set.".red()
+            );
+        }
         std::process::exit(1);
     }
 

--- a/src/git_funcs.rs
+++ b/src/git_funcs.rs
@@ -90,10 +90,10 @@ pub async fn get_pr_info(
 
     let response = request.send().await?;
 
-    if response.status() == StatusCode::UNAUTHORIZED {
+    if response.status() != StatusCode::OK {
         eprintln!(
             "{}",
-            "Error: Unauthorized. Please set GH_PR_TOKEN environment variable.".red()
+            "Error: GitHub API request failed. If this is a private repo, GH_PR_TOKEN environment variable must be set.".red()
         );
         std::process::exit(1);
     }

--- a/src/git_funcs.rs
+++ b/src/git_funcs.rs
@@ -89,21 +89,21 @@ pub async fn get_pr_info(
     };
 
     let response = request.send().await?;
-
+    let mut error= String::new();
     if response.status() != StatusCode::OK {
-        eprintln!(
+        error.push_str(&format!(
             "{} {}",
-            "Error: GitHub API request failed. HTTP Status:".red(),
-            response.status().as_str().red()
-        );
+            "GitHub API request failed. HTTP Status:",
+            response.status()
+        ));
         if response.status() == reqwest::StatusCode::NOT_FOUND
             || response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            eprintln!(
+            error.push_str(&format!(
                 "{}",
-                "If this is a private repo, GH_PR_TOKEN environment variable must be set.".red()
-            );
+                "\nIf this is a private repo, GH_PR_TOKEN environment variable must be set."
+            ));
         }
-        std::process::exit(1);
+        return Err(error.into())
     }
 
     let files_info: Vec<File> = response.json().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let review_comments = ai_funcs::code_review(prompt).await;
         match review_comments {
             Ok(_) => {
-                println!("\n\n== END OF COMMENTS ==");
                 process::exit(0);
             }
             Err(e) => {
@@ -42,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         process::exit(1);
     });
 
-    println!("Getting PR data: {}/{} #{}", owner, repo, pr_number);
+    println!("Analysing PR changes: {}/{} #{}\n", owner, repo, pr_number);
     match git_funcs::get_pr_info(&owner, &repo, pr_number).await {
         Ok(pr_info) => {
             let mut output = String::new();
@@ -53,16 +52,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
                 utils::append_with_newline(&file.patch, &mut output);
             }
-            println!("Analysing changes...\n");
             let review_result = ai_funcs::code_review(output).await;
-            match review_result {
-                Ok(_) => {
-                    println!("\n\n== END ==");
-                }
-                Err(e) => {
-                    eprintln!("Failed to analyse code: {}", e);
-                    process::exit(1);
-                }
+            if let Err(e) = review_result {
+                eprintln!("Failed to analyze code: {}", e);
+                process::exit(1);
             }
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ mod utils;
 use clap::Parser;
 use std::process;
 use utils::Args;
+use colored::Colorize;
+
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -59,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         Err(e) => {
-            eprintln!("Failed to get PR info: {}", e);
+            eprintln!("{}", &format!("Failed to get PR info: {}", e).red());
             process::exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let review_result = ai_funcs::code_review(output).await;
             match review_result {
                 Ok(_) => {
-                    println!("\n\n== END OF COMMENTS ==");
+                    println!("\n\n== END ==");
                 }
                 Err(e) => {
                     eprintln!("Failed to analyse code: {}", e);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,9 +3,13 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[command(author, version, long_about = "AI Code Review Tool")]
 pub struct Args {
+    /// The owner of the repo; required if not running locally
     pub owner: Option<String>,
+    /// The repo name; required if not running locally
     pub repo: Option<String>,
+    /// The PR number as an integer; required if not running locally
     pub pr: Option<u32>,
+    /// Run locally inside git repository, comparing HEAD against main (branch named `main` must exist)
     #[arg(short, long, action = clap::ArgAction::SetTrue)]
     pub local: bool,
 }


### PR DESCRIPTION
The code now checks for the presence of an environment variable 'GH_PR_TOKEN' storing the GitHub token. If the variable is found, it adds an Authorization header to the HTTP request. This is required for private repos, but not for public ones.

Also includes some refactoring and tidying changes.